### PR TITLE
Make GitHub detect *.okf as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.okf linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.okf` files as Forth.  It will also classify the entire repository as Forth.
